### PR TITLE
Issue #0000 fix: s3n changed to s3a for S3 data fetcher

### DIFF
--- a/analytics-core/src/main/scala/org/ekstep/analytics/framework/fetcher/S3DataFetcher.scala
+++ b/analytics-core/src/main/scala/org/ekstep/analytics/framework/fetcher/S3DataFetcher.scala
@@ -21,7 +21,7 @@ object S3DataFetcher {
 
         val keys = for(query <- queries) yield {
             val paths = if(query.folder.isDefined && query.endDate.isDefined && query.folder.getOrElse("false").equals("true")) {
-                Array("s3n://"+getBucket(query.bucket)+"/"+getPrefix(query.prefix) + query.endDate.get)
+                Array("s3a://"+getBucket(query.bucket)+"/"+getPrefix(query.prefix) + query.endDate.get + "*")
             } else {
                 getKeys(query);
             }


### PR DESCRIPTION
s3n changed to s3a for S3 data fetcher. Also the endDate is changed to support regex at the end. As. result, If we just pass a endDate as **2023-01-12** in the request payload, then all corresponding files related to this date will be fetched.

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
